### PR TITLE
use an info.py file to allow integration with casa-distro/bv_maker

### DIFF
--- a/colorado/info.py
+++ b/colorado/info.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+version_major = 0
+version_minor = 2
+version_micro = 0
+version_extra = ''
+
+# Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
+__version__ = "%s.%s.%s%s" % (version_major,
+                              version_minor,
+                              version_micro,
+                              version_extra)
+CLASSIFIERS = [
+    "Programming Language :: Python",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Operating System :: OS Independent"]
+
+
+description = "A plotly interface for pyAims (brain images)"
+
+# versions for dependencies
+SPHINX_MIN_VERSION = '1.0'
+
+# Main setup parameters
+NAME = 'Colorado'
+PROJECT = 'colorado'
+ORGANISATION = "neurospin"
+MAINTAINER = "nobody"
+MAINTAINER_EMAIL = "support@neurospin.info"
+DESCRIPTION = description
+URL = "https://github.com/neurospin/colorado"
+DOWNLOAD_URL = "https://github.com/neurospin/colorado"
+LICENSE = "CeCILL-B"
+AUTHOR = "Marco Pascucci"
+AUTHOR_EMAIL = 'marpas.paris@gmail.com'
+PLATFORMS = "OS Independent"
+PROVIDES = ["colorado"]
+REQUIRES = ['plotly', 'numpy', 'dico_toolbox']
+EXTRA_REQUIRES = {
+    "doc": ["sphinx>=" + SPHINX_MIN_VERSION]}
+
+brainvisa_build_model = 'pure_python'
+

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,21 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(name='Colorado',
-                 version='0.2.0',
-                 description="A plotly interface for pyAims (brain images)",
-                 author='Marco Pascucci',
+release_info = {}
+python_dir = os.path.dirname(__file__)
+with open(os.path.join(python_dir, "colorado", "info.py")) as f:
+    code = f.read()
+    exec(code, release_info)
+
+setuptools.setup(name=release_info['NAME'],
+                 version=release_info['__version__'],
+                 description=release_info['DESCRIPTION'],
+                 author=release_info['AUTHOR'],
+                 author_email=release_info['AUTHOR_EMAIL']
                  long_description=long_description,
                  long_description_content_type="text/markdown",
-                 author_email='marpas.paris@gmail.com',
-                 url='',
+                 url=release_info['URL'],
                  packages=['colorado'],
-                 install_requires=['plotly', 'numpy', 'dico_toolbox'],
-                 classifiers=[
-                     "Programming Language :: Python",
-                     "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-                     "Operating System :: OS Independent",
-                 ]
+                 install_requires=release_info["REQUIRES"],
+                 classifiers=release_info["CLASSIFIERS"]
                  )


### PR DESCRIPTION
this is just a separation of what was in setup.py into 2 files, the
info.py file being read by bv_maker not only for setup. Moreover it
allows to get info at runtime (to get library version etc) when needed.